### PR TITLE
Added Option to See Purchasing Agents

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <button type="button" id="manufacturing-button">Manufacturing Companies</button><button type="button" id="agents">Purchasing Agents</button>
     <article id="active-businesses">
     </article>
-
     <script src="./scripts/main.js" type="module"></script>
 </body>
 </html>

--- a/scripts/agents.js
+++ b/scripts/agents.js
@@ -1,0 +1,20 @@
+import { getBusinesses } from "./database.js"
+
+const businessList = getBusinesses()
+
+const agentsHTML = document.getElementById("active-businesses")
+
+export let agentList = []
+
+//Display just the purchasing agents
+    export const showAgetns = () => {
+    businessList.map(business => {
+        let html =  /*html*/ `<section id="agent">
+        ${business.purchasingAgent.nameFirst} ${business.purchasingAgent.nameLast}
+        </section>`
+        agentList.push(html)
+    } )
+    agentsHTML.innerHTML = agentList.join(``)
+    header.innerHTML = "Active Agents"
+    agentList = []
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,21 +2,26 @@
 import { businessList } from "./BusinessList.js"
 import { renderNewYork } from "./new-york.js"
 import { renderManufacturing } from "./manufacutring.js"
+import { showAgetns } from "./agents.js"
 
 //Create a references to the articles/buttons in the html
 const activeBusinesses = document.getElementById("active-businesses")
 const newYorkButton = document.getElementById("new-york-button")
 const manufacturingButton = document.getElementById("manufacturing-button")
 const homeButton = document.getElementById("home-button")
+const agentButton = document.getElementById("agents")
+const header = document.getElementById("header")
 
 //Set initial html to a list of all companies
 const renderHTML = () => {activeBusinesses.innerHTML = businessList.join(``)}
 renderHTML()
 
+
 //Add event listeners
 homeButton.addEventListener(
     "click",
     (evt) => {
+        header.innerHTML = `Active Businesses`
         renderHTML()
     }
 )
@@ -24,13 +29,25 @@ homeButton.addEventListener(
 newYorkButton.addEventListener(
     "click",
     (evt) => {
-        renderNewYork()
+        if (header.innerHTML !== "New York Businesses"){
+            renderNewYork()
+        }
     }
 )
 
 manufacturingButton.addEventListener(
     "click",
-    (evt) => {
-        renderManufacturing()
+    (evt) => { 
+        if (header.innerHTML !== "Manufacutring Bussinesses"){
+            renderManufacturing()
+        }
+    }
+    )
+    
+    agentButton.addEventListener(
+        "click",
+        (evt) => {
+            if (header.innerHTML !== "Active Agents")
+            showAgetns()
     }
 )

--- a/scripts/manufacutring.js
+++ b/scripts/manufacutring.js
@@ -5,7 +5,7 @@ const businesses = getBusinesses()
 const activeBusinesses = document.getElementById("active-businesses")
 
 //Create an array to store the html of the manufacturing companies in
-const manufacturingBusinesses = []
+export let manufacturingBusinesses = []
 
 //Rerender html to display manufacturing companies
 export const renderManufacturing = () => {
@@ -18,6 +18,7 @@ export const renderManufacturing = () => {
     </section>`
     manufacturingBusinesses.push(html)
     })
-    header.outerHTML = `<h1 id="header">Manufacturing Businesses</h1>` 
+    header.innerHTML = `Manufacturing Businesses` 
     activeBusinesses.innerHTML = manufacturingBusinesses.join(``)
+    manufacturingBusinesses = []
 }

--- a/scripts/new-york.js
+++ b/scripts/new-york.js
@@ -5,20 +5,21 @@ const activeBusinesses = document.getElementById("active-businesses")
 const businesses = getBusinesses()
 
 //Create an array to store the new york companies in
-const newYorkBusinesses = []
+let newYorkBusinesses = []
 
 
 //Rerender html to display new york companies
 export const renderNewYork = () => {
     const filteredBusinesses = businesses.filter(business => business.addressStateCode === "NY")
     filteredBusinesses.forEach((business) => {
-        let html /*html*/ = `<section id="business" >
+        let html  = /*html*/ `<section id="business" >
         <h2>${business.companyName}</h2>
         ${business.addressFullStreet} <br>
         ${business.addressCity} ${business.addressStateCode}, ${business.addressZipCode}
         </section>`
         newYorkBusinesses.push(html)
     })
-    header.outerHTML = `<h1 id="header">New York Businesses</h1>`
+    header.innerHTML = `New York Businesses`
     activeBusinesses.innerHTML = newYorkBusinesses.join(``)
+    newYorkBusinesses = []
 }


### PR DESCRIPTION
Added another button to the top of the page that allows the user to filter what they're seeing to just the names of the purchasing agents. (Also fixed a bug where the list of filtered companies would appear multiple times.) 

STEPS TO TEST:
1. Pull and serve the code locally
2. Click the "Purchasing Agents" button and verify the page displays a list of names of purchasing agents.
3. Click through the other filter options to test if multiple lists appear on screen.